### PR TITLE
Improve content negotiation

### DIFF
--- a/app/Http/Controllers/AssembliesController.php
+++ b/app/Http/Controllers/AssembliesController.php
@@ -20,40 +20,7 @@ class AssembliesController extends Controller
     {
         $assemblies = Assembly::all();
 
-        if ($request->acceptsHtml()) {
-            return view('assemblies.index_html', compact('assemblies'));
-
-        } elseif ($request->accepts('text/xml')) {
-
-            // We use a Blade view to render the XML tree.
-            $xml = view('assemblies.index_xml', compact('assemblies'))->render();
-
-            return response($xml, 200, [
-                'Content-Type' => 'text/xml',
-            ]);
-
-        } elseif ($request->accepts('text/csv')) {
-
-            // Create file in memory.
-            $csv = Writer::createFromFileObject(new SplTempFileObject());
-
-            // Insert the CSV headers.
-            $csv->insertOne(['identifier', 'name_en', 'name_fr', 'name_nl']);
-
-            // Insert the data.
-            $assemblies->each(function ($item) use ($csv) {
-                $csv->insertOne(array_values($item->toArray()));
-            });
-
-            // Generate a reponse.
-            return response((string) $csv, 200, [
-                'Content-Type' => 'text/csv',
-                'Content-Transfer-Encoding' => 'binary',
-            ]);
-        }
-
-        // Fall back on JSON by default.
-        return Assembly::all();
+        return $this->renderResource($assemblies, ['id' => 'identifier']);
     }
 
     /**
@@ -68,37 +35,6 @@ class AssembliesController extends Controller
     {
         $assembly = Assembly::findOrFail($id);
 
-        if ($request->acceptsHtml()) {
-            return view('assemblies.show_html', compact('assembly'));
-
-        } elseif ($request->accepts('text/xml')) {
-
-            // We use a Blade view to render the XML tree.
-            $xml = view('assemblies.show_xml', compact('assembly'))->render();
-
-            return response($xml, 200, [
-                'Content-Type' => 'text/xml',
-            ]);
-
-        } elseif ($request->accepts('text/csv')) {
-
-            // Create file in memory.
-            $csv = Writer::createFromFileObject(new SplTempFileObject());
-
-            // Insert the CSV headers.
-            $csv->insertOne(['identifier', 'name_en', 'name_fr', 'name_nl']);
-
-            // Insert the data.
-            $csv->insertOne(array_values($assembly->toArray()));
-
-            // Generate a reponse.
-            return response((string) $csv, 200, [
-                'Content-Type' => 'text/csv',
-                'Content-Transfer-Encoding' => 'binary',
-            ]);
-        }
-
-        // Fall back on JSON by default.
-        return Assembly::find($id);
+        return $this->renderResource($assembly, ['id' => 'identifier']);
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,12 +2,164 @@
 
 namespace App\Http\Controllers;
 
+use SplTempFileObject;
+use League\Csv\Writer as CsvWriter;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    /**
+     * Send a response in a format based on content-negotiation.
+     *
+     * The `$keyMappings` parameter can be used to replace key names coming from
+     * Eloquent by keys that can be more appropriate for a given context.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $resource
+     * @param  array|null  $keyMappings
+     *
+     * @return \Illuminate\Http\Response|\Illuminate\Contracts\View\View|\Illuminate\Database\Eloquent\Collection
+     */
+    protected function renderResource($resource, $keyMappings = null)
+    {
+        $resourceName = $this->findResourceName($resource);
+
+        $renderMethod = 'render'.Request::getRequestFormat();
+
+        if (!method_exists($this, $renderMethod)) {
+            throw new Exception("There is no [{$renderMethod}] method.");
+        }
+
+        return $this->$renderMethod($resourceName, $resource, $keyMappings);
+    }
+
+    /**
+     * Retrieve the (plural) name of a resource, based on which controller was called.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $resource
+     *
+     * @return string
+     */
+    protected function findResourceName($resource)
+    {
+        // Use ‘late static binding’ to retrieve the controller the method
+        // was called in (instead of getting this very class).
+        $controllerClass = class_basename(get_called_class());
+
+        return str_replace('controller', '', strtolower($controllerClass));
+    }
+
+    /**
+     * Render the given data as a JSON object or array.
+     *
+     * @param  string  $resourceName
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $data
+     * @param  array|null  $keyMappings
+     *
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     */
+    protected function renderJson($resourceName, $data, $keyMappings = null)
+    {
+        return $data;
+    }
+
+    /**
+     * Render the given data as a CSV string.
+     *
+     * @param  string  $resourceName
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $data
+     * @param  array|null  $keyMappings
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function renderCsv($resourceName, $data, $keyMappings = null)
+    {
+        // Create a temporary file in memory.
+        $csv = CsvWriter::createFromFileObject(new SplTempFileObject());
+
+        // Get the CSV headers.
+        if ($data instanceof EloquentCollection) {
+            $headers = array_keys($data->first()->toArray());
+        } else {
+            $headers = array_keys($data->toArray());
+        }
+
+        // Apply key mappings if needed. This is useful to replace
+        // normal keys coming from Eloquent by keys that can be
+        // tailored for a specific purpose.
+        foreach (array_wrap($keyMappings) as $oldKeyName => $newKeyName) {
+            if (($pos = array_search($oldKeyName, $headers)) !== false) {
+                $headers[$pos] = $newKeyName;
+            }
+        }
+
+        // Insert the CSV headers.
+        $csv->insertOne($headers);
+
+        // Insert the data.
+        if ($data instanceof EloquentCollection) {
+            $data->each(function ($item) use ($csv) {
+                $csv->insertOne(array_values($item->toArray()));
+            });
+        } else {
+            $csv->insertOne(array_values($data->toArray()));
+        }
+
+        // Generate a reponse.
+        return response((string) $csv, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Transfer-Encoding' => 'binary',
+        ]);
+    }
+
+    /**
+     * Render the given data as an HTML view.
+     *
+     * @param  string  $resourceName
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $data
+     * @param  array|null  $keyMappings
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    protected function renderHtml($resourceName, $data, $keyMappings = null)
+    {
+        if ($data instanceof EloquentCollection) {
+            return view("{$resourceName}.index_html", [$resourceName => $data]);
+        }
+
+        return view("{$resourceName}.show_html", [
+            str_singular($resourceName) => $data
+        ]);
+    }
+
+    /**
+     * Render the given data as an XML view.
+     *
+     * @param  string  $resourceName
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection  $data
+     * @param  array|null  $keyMappings
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    protected function renderXml($resourceName, $data, $keyMappings = null)
+    {
+        // We use a Blade view to render the XML tree.
+        if ($data instanceof EloquentCollection) {
+            $view = view("{$resourceName}.index_xml", [$resourceName => $data]);
+        } else {
+            $view = view("{$resourceName}.show_xml", [
+                str_singular($resourceName) => $data
+            ]);
+        }
+
+        return response($view->render(), 200, [
+            'Content-Type' => 'text/xml',
+        ]);
+    }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \App\Http\Middleware\NegotiateContent::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,

--- a/app/Http/Middleware/NegotiateContent.php
+++ b/app/Http/Middleware/NegotiateContent.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A middleware that determines the response
+ * format that is preferred by the client.
+ */
+class NegotiateContent
+{
+    /**
+     * A list of response content types supported by the different routes.
+     *
+     * @var array
+     */
+    protected $availableContentTypesForPaths = [
+        'assemblies' => [
+            'application/json',
+            'text/csv',
+            'text/html',
+            'text/xml',
+        ],
+        'assemblies/.+' => [
+            'application/json',
+            'text/csv',
+            'text/html',
+            'text/xml',
+        ],
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $this->initializeFormats($request);
+
+        // Find what are the available media types for the current request.
+        $availableTypes = $this->getAvailableTypes($request->path());
+
+        $acceptedType = $request->prefers($availableTypes);
+
+        // If we cannot provide the resource in any of the formats
+        // that are accepted by the client, we abort the request.
+        if ($acceptedType) {
+            abort(
+                Response::HTTP_NOT_ACCEPTABLE,
+                'The supported formats are: '.implode(', ', $availableTypes).'.'
+            );
+        }
+
+        // Register the accepted format on the request object to make
+        // this info available to subsequent code or middleware.
+        $request->setRequestFormat(
+            $request->getFormat($acceptedType)
+        );
+
+        return $next($request);
+    }
+
+    /**
+     * Register supported formats that the Symfony request doesn’t know about.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     *
+     * @return void
+     */
+    protected function initializeFormats($request)
+    {
+        $request->setFormat('csv', 'text/csv');
+    }
+
+    /**
+     * Find what are the available media types for the current request.
+     *
+     * @param  string  $path  The path of the current request
+     *
+     * @return array
+     */
+    protected function getAvailableTypes($path)
+    {
+        $paths = array_reverse($this->availableContentTypesForPaths);
+
+        foreach ($paths as $path => $availableContentTypes) {
+            if (preg_match("!{$path}!", $path)) {
+                return $availableContentTypes;
+            }
+        }
+
+        return [];
+    }
+}

--- a/app/Http/Middleware/NegotiateContent.php
+++ b/app/Http/Middleware/NegotiateContent.php
@@ -50,7 +50,7 @@ class NegotiateContent
 
         // If we cannot provide the resource in any of the formats
         // that are accepted by the client, we abort the request.
-        if ($acceptedType) {
+        if (!$acceptedType) {
             abort(
                 Response::HTTP_NOT_ACCEPTABLE,
                 'The supported formats are: '.implode(', ', $availableTypes).'.'

--- a/resources/views/errors/406.blade.php
+++ b/resources/views/errors/406.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Non-acceptable request</title>
+
+    <style>
+        /* Create a small Belgian flag at the top of the page. */
+        html:before {
+            content: '';
+            display: block;
+            height: 3px;
+            background-image: linear-gradient(
+                to right,
+                #000, #000 33%,
+                #ffe936 33%, #ffe936 66%,
+                #ff0f21 66%, #ff0f21
+            );
+            box-shadow: 0 1px 5px rgba(0,0,0,.15);
+        }
+        body {
+            margin: 2em;
+            background-color: #fff;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <p>The resource you are looking cannot be provided in any of the formats you accept.</p>
+</body>
+</html>

--- a/resources/views/errors/406.blade.php
+++ b/resources/views/errors/406.blade.php
@@ -27,6 +27,7 @@
     </style>
 </head>
 <body>
-    <p>The resource you are looking cannot be provided in any of the formats you accept.</p>
+    <p>The resource you are looking for cannot be provided in any of the formats you accept.</p>
+    <p>{{ $exception->getMessage() }}</p>
 </body>
 </html>

--- a/tests/Feature/AssemblyTest.php
+++ b/tests/Feature/AssemblyTest.php
@@ -159,4 +159,11 @@ class AssemblyTest extends TestCase
     {
         $this->get('/assemblies/z')->assertStatus(Response::HTTP_NOT_FOUND);
     }
+
+    /** @test */
+    function get_a_not_acceptable_response_if_wanting_data_in_an_unavailable_format()
+    {
+        $this->get('/assemblies/k', ['accept' => 'foo/bar',])
+             ->assertStatus(Response::HTTP_NOT_ACCEPTABLE);
+    }
 }


### PR DESCRIPTION
This does several things to improve content negotiation:

1. Adding a middleware to do content negotiation as soon as possible in the request life cycle.
    - If negotiation succeeds, the info of the chosen format is stored on the request so that it can be retrieved and used later to generate an appropriate response.
    - If negotiation fails, the middleware aborts the request and sends an HTTP `406 Not acceptable` response. This response lists the supported formats for the targeted URL.
2. Extracting the formatting logic to a centralized place in the base controller of the application, and making this logic more generic.